### PR TITLE
add null defense code for when there are no properties

### DIFF
--- a/spring-social-kakao/src/main/java/org/springframework/social/kakao/api/KakaoProfileProperties.java
+++ b/spring-social-kakao/src/main/java/org/springframework/social/kakao/api/KakaoProfileProperties.java
@@ -21,5 +21,5 @@ public class KakaoProfileProperties extends KakaoObject implements Serializable 
 		return profile_image;
 	}
 
-	KakaoProfileProperties(){}
+	public KakaoProfileProperties(){}
 }

--- a/spring-social-kakao/src/main/java/org/springframework/social/kakao/connect/KakaoAdapter.java
+++ b/spring-social-kakao/src/main/java/org/springframework/social/kakao/connect/KakaoAdapter.java
@@ -16,6 +16,8 @@ public class KakaoAdapter implements ApiAdapter<Kakao> {
 	
 	public void setConnectionValues(Kakao kakao, ConnectionValues values) {
 		KakaoProfile profile = kakao.userOperation().getUserProfile();
+		KakaoProfileProperties properties = profile.getProperties();
+		if(properties == null) properties = new KakaoProfileProperties();
 		values.setProviderUserId(Long.toString(profile.getId()));
 		values.setDisplayName(profile.getProperties().getNickname());
 		values.setProfileUrl("");


### PR DESCRIPTION
가끔 KakaoAdapter.java 20 번 째라인인
values.setDisplayName(profile.getProperties().getNickname());
요 부분에서 NullPointerException이 나길래 혹시 몰라 properties가 Null 일 수도 있겠다 싶어서
방어 코드를 작성했습니다.